### PR TITLE
Use eslint-plugin-strict-dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,31 @@
+const dRef = ["src/index.ts", "examples/**/*"];
+const depRules = [
+  {
+    module: "src/express",
+    allowReferenceFrom: [...dRef],
+    allowSameModule: true,
+  },
+  {
+    module: "src/fastify",
+    allowReferenceFrom: [...dRef],
+    allowSameModule: false,
+  },
+  {
+    module: "src/fetch",
+    allowReferenceFrom: [...dRef],
+    allowSameModule: true,
+  },
+  {
+    module: "src/json",
+    allowReferenceFrom: [...dRef, "src/fetch"],
+    allowSameModule: false,
+  },
+  {
+    module: "src/zod",
+    allowReferenceFrom: [...dRef, "src/express/zod", "src/fastify/zod"],
+    allowSameModule: true,
+  },
+];
 module.exports = {
   env: {
     browser: false,
@@ -15,7 +43,13 @@ module.exports = {
     ecmaVersion: "latest",
     sourceType: "module",
   },
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "strict-dependencies"],
   ignorePatterns: ["**/dist/*", "docs/**/*"],
-  rules: {},
+  rules: {
+    "strict-dependencies/strict-dependencies": [
+      "error",
+      depRules,
+      { resolveRelativeImport: true },
+    ],
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "dotenv-cli": "^7.2.1",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.0.0",
+        "eslint-plugin-strict-dependencies": "^1.3.13",
         "npm-run-all2": "^7.0.0",
         "prettier": "^3.0.0",
         "supertest": "^7.0.0",
@@ -2525,6 +2526,19 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-plugin-strict-dependencies": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-strict-dependencies/-/eslint-plugin-strict-dependencies-1.3.13.tgz",
+      "integrity": "sha512-N2zW2eM+YmgKpZrhFvKrDGtaNUzQWxIzzjL3sJb6PjUWPiXD0/n4VghDgml+JAXSX7u7V+FANMjsvWBGblUd5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-glob": "4.0.3",
+        "micromatch": "4.0.8",
+        "normalize-path": "3.0.0",
+        "require-strip-json-comments": "2.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -3877,10 +3891,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -4006,6 +4021,16 @@
       "peer": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm-normalize-package-bin": {
@@ -4643,6 +4668,16 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-strip-json-comments": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-strip-json-comments/-/require-strip-json-comments-2.0.0.tgz",
+      "integrity": "sha512-Pta3KVBaVZ9DHMoOGRd+3PEc/EFZAQ1JVHQpKZfPo018fdT9iEsyPBzqNAgJAzKMF4kbr5G7GaqP0+UOwnGfPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "strip-json-comments": "^3.0"
       }
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dotenv-cli": "^7.2.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-strict-dependencies": "^1.3.13",
     "npm-run-all2": "^7.0.0",
     "prettier": "^3.0.0",
     "supertest": "^7.0.0",


### PR DESCRIPTION
eslint-plugin-strict-dependenciesを利用して、不正なモジュール間依存を防ぐ