### PR TITLE
Add JsonStringifyResult type

### DIFF
--- a/pkgs/typed-api-spec/.eslintrc.js
+++ b/pkgs/typed-api-spec/.eslintrc.js
@@ -1,4 +1,4 @@
-const dRef = ["src/index.ts", "misc/**/*", "**/*.test.ts"];
+const dRef = ["src/index.ts", "misc/**/*", "**/*.test.ts", "**/*.t-test.ts"];
 const depRules = [
   {
     module: "src/express",
@@ -17,7 +17,7 @@ const depRules = [
   },
   {
     module: "src/json",
-    allowReferenceFrom: [...dRef, "src/fetch"],
+    allowReferenceFrom: [...dRef, "src/fetch", "src/core"],
     allowSameModule: false,
   },
   {

--- a/pkgs/typed-api-spec/src/core/spec.ts
+++ b/pkgs/typed-api-spec/src/core/spec.ts
@@ -3,6 +3,7 @@ import { ClientResponse, StatusCode } from "./hono-types";
 import { C } from "../compile-error-utils";
 import { JSONSchema7 } from "json-schema";
 import { StandardSchemaV1 } from "@standard-schema/spec";
+import { JsonStringifyResult } from "../json";
 
 /**
  * { // ApiEndpoints
@@ -230,7 +231,7 @@ export type AnyResponse = DefineResponse<any, any>;
 export type JsonSchemaResponse = DefineResponse<JSONSchema7, JSONSchema7>;
 export type ApiClientResponses<AResponses extends AnyApiResponses> = {
   [SC in keyof AResponses & StatusCode]: ClientResponse<
-    ApiResBody<AResponses, SC>,
+    JsonStringifyResult<ApiResBody<AResponses, SC>>,
     SC,
     "json",
     ApiResHeaders<AResponses, SC>

--- a/pkgs/typed-api-spec/src/fetch/index.t-test.ts
+++ b/pkgs/typed-api-spec/src/fetch/index.t-test.ts
@@ -6,7 +6,7 @@ import {
   ToApiEndpoints,
 } from "../core";
 import FetchT, { ValidateUrl } from "./index";
-import JSONT from "../json";
+import JSONT, { JsonStringifyResult } from "../json";
 import { Equal, Expect } from "../core/type-test";
 import { C } from "../compile-error-utils";
 import { ApiEndpointsSchema } from "../../dist";
@@ -383,6 +383,27 @@ type ValidateUrlTestCase = [
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const _body: ResBody = await res.json();
+    }
+  })();
+}
+
+{
+  const ResBody = z.object({ userId: z.date() });
+  type ResBody = z.infer<typeof ResBody>;
+  const spec = {
+    "/": {
+      get: {
+        responses: { 200: { body: ResBody } },
+      },
+    },
+  } satisfies ApiEndpointsSchema;
+  (async () => {
+    const f = fetch as FetchT<"", ToApiEndpoints<typeof spec>>;
+    {
+      const res = await f("/", {});
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _body: JsonStringifyResult<ResBody> = await res.json();
     }
   })();
 }

--- a/pkgs/typed-api-spec/src/fetch/index.ts
+++ b/pkgs/typed-api-spec/src/fetch/index.ts
@@ -141,7 +141,7 @@ type FetchT<UrlPrefix extends UrlPrefixPattern, E extends ApiEndpoints> = <
     : never,
   LM extends Lowercase<InputMethod>,
   Query extends ApiP<E, CandidatePaths, LM, "query">,
-  ResBody extends ApiP<
+  Response extends ApiP<
     E,
     CandidatePaths,
     LM,
@@ -165,7 +165,7 @@ type FetchT<UrlPrefix extends UrlPrefixPattern, E extends ApiEndpoints> = <
     ApiP<E, CandidatePaths, LM, "headers">,
     InputMethod
   >,
-) => Promise<ResBody>;
+) => Promise<Response>;
 
 export default FetchT;
 

--- a/pkgs/typed-api-spec/src/json/index.test.ts
+++ b/pkgs/typed-api-spec/src/json/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { JsonStringifyResult } from ".";
+import { Equal, Expect } from "../core/type-test";
+
+const l: unique symbol = Symbol("l");
+describe("JsonStringifyResult", () => {
+  it("should work", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type MyType = {
+      a: string;
+      b: number;
+      c: boolean;
+      d: null;
+      e: undefined;
+      f: () => void;
+      g: symbol;
+      h: bigint;
+      i: Date;
+      j: { nested: string; undef: undefined };
+      k: (string | undefined | Date)[];
+      [l]: string;
+      m: { toJSON: () => { x: number; y: string | undefined } };
+    };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    type T = Expect<
+      Equal<
+        JsonStringifyResult<MyType>,
+        {
+          a: string;
+          b: number;
+          c: boolean;
+          d: null;
+          i: string;
+          j: { nested: string };
+          k: (string | null)[];
+          // FIXME: y should be optional
+          m: { x: number; y: string | undefined };
+        }
+      >
+    >;
+
+    const example: MyType = {
+      a: "hello",
+      b: 123,
+      c: true,
+      d: null,
+      e: undefined,
+      f: () => {
+        console.log("func");
+      },
+      g: Symbol("g"),
+      h: 123n,
+      i: new Date(),
+      j: { nested: "world", undef: undefined },
+      k: ["a", undefined, new Date("2021-01-01")],
+      [l]: "symbol keyed value",
+      m: { toJSON: () => ({ x: 1, y: undefined }) },
+    };
+
+    expect(JSON.parse(JSON.stringify({ ...example, h: undefined }))).toEqual({
+      a: "hello",
+      b: 123,
+      c: true,
+      d: null,
+      i: example.i.toISOString(),
+      j: { nested: "world" },
+      k: ["a", null, "2021-01-01T00:00:00.000Z"],
+      m: { x: 1 },
+    });
+  });
+});

--- a/pkgs/typed-api-spec/src/json/index.ts
+++ b/pkgs/typed-api-spec/src/json/index.ts
@@ -5,10 +5,62 @@ export type JSON$stringifyT = <T>(
   data: T,
   replacer?: undefined,
   space?: number | string | undefined,
-) => TypedString<T>;
+) => TypedString<JsonStringifyResult<T>>;
 
 type JSONT = Omit<JSON, "stringify"> & {
   stringify: JSON$stringifyT;
 };
 
 export default JSONT;
+
+// JSONとして有効なプリミティブ型 + Date
+type JsonPrimitive = string | number | boolean | null | Date;
+
+// undefined | function | symbol | bigint は JSON化できない (除外 or null or エラー)
+// eslint-disable-next-line @typescript-eslint/ban-types
+type InvalidJsonValue = undefined | Function | symbol | bigint;
+
+// 配列要素の変換: 不適切な値は null に
+type JsonifyArrayElement<T> = T extends InvalidJsonValue ? null : Jsonify<T>;
+
+// オブジェクトの変換
+type JsonifyObject<T> = {
+  // keyof T から string 型のキーのみを抽出 (シンボルキーを除外)
+  [K in keyof T as K extends string
+    ? // プロパティの値 T[K] を Jsonify した結果を ProcessedValue とする
+      Jsonify<T[K]> extends infer ProcessedValue
+      ? // ProcessedValue が 不適切な型なら、このプロパティ自体を除外 (never)
+        ProcessedValue extends InvalidJsonValue
+        ? never
+        : // そうでなければキー K を採用
+          K
+      : never
+    : never]: Jsonify<T[K]>; // ↑で採用されたキー K に対して、変換後の値 ProcessedValue を割り当て
+};
+
+// メインの再帰型
+type Jsonify<T> =
+  // 1. toJSONメソッドを持つか？ -> あればその返り値を Jsonify
+  T extends { toJSON(): infer R }
+    ? Jsonify<R>
+    : // 2. Dateか？ -> string
+      T extends Date
+      ? string
+      : // 3. その他のプリミティブか？ -> そのまま
+        T extends JsonPrimitive
+        ? T
+        : // 4. 不適切な値か？ -> そのまま (呼び出し元で処理)
+          T extends InvalidJsonValue
+          ? T
+          : // 5. 配列か？ -> 各要素を JsonifyArrayElement で変換
+            T extends Array<infer E>
+            ? Array<JsonifyArrayElement<E>>
+            : // 6. オブジェクトか？ -> JsonifyObject で変換
+              T extends object
+              ? JsonifyObject<T>
+              : // 7. それ以外 (通常は到達しない) -> never
+                never;
+
+// 最終的な型: トップレベルでの undefined/function/symbol/bigint は undefined になる
+export type JsonStringifyResult<T> =
+  Jsonify<T> extends InvalidJsonValue ? undefined : Jsonify<T>;


### PR DESCRIPTION
This pull request includes several changes to the `typed-api-spec` package, focusing on enhancing JSON handling and adding new test cases. The most important changes are the introduction of the `JsonStringifyResult` type, updates to the `FetchT` type, and modifications to the ESLint configuration.

### Enhancements to JSON handling:

* [`pkgs/typed-api-spec/src/json/index.ts`](diffhunk://#diff-12aeec546b44b4b802c57f8c8e3040497d486fc6fa77bb72bd4ad5b06eff5c32L8-R66): Introduced the `JsonStringifyResult` type to handle JSON stringification results, including support for complex types like `Date`, and added detailed type transformations for JSON-compatible structures.
* [`pkgs/typed-api-spec/src/json/index.test.ts`](diffhunk://#diff-7962c46348d0e41ce75116566a4215ad32bf7a3353e4c07098db365b445f269eR1-R71): Added new test cases to validate the `JsonStringifyResult` type, ensuring correct handling of various data types and structures.

### Updates to FetchT type:

* [`pkgs/typed-api-spec/src/fetch/index.ts`](diffhunk://#diff-fab7b7d499325d868bb244d554326cafe387c331d52b0a756f04ac94b854c04bL144-R144): Renamed the `ResBody` type parameter to `Response` in the `FetchT` type and updated the return type to `Promise<Response>`. [[1]](diffhunk://#diff-fab7b7d499325d868bb244d554326cafe387c331d52b0a756f04ac94b854c04bL144-R144) [[2]](diffhunk://#diff-fab7b7d499325d868bb244d554326cafe387c331d52b0a756f04ac94b854c04bL168-R168)

### Modifications to ESLint configuration:

* [`pkgs/typed-api-spec/.eslintrc.js`](diffhunk://#diff-bf444c6e06f56e9ead0a40ce3b84a905ad0c16f696b6bcd7ceb999379482229eL1-R1): Added a new file pattern `**/*.t-test.ts` to the `dRef` array and updated the `depRules` to allow references from `src/core`. [[1]](diffhunk://#diff-bf444c6e06f56e9ead0a40ce3b84a905ad0c16f696b6bcd7ceb999379482229eL1-R1) [[2]](diffhunk://#diff-bf444c6e06f56e9ead0a40ce3b84a905ad0c16f696b6bcd7ceb999379482229eL20-R20)

### Additional changes:

* [`pkgs/typed-api-spec/src/core/spec.ts`](diffhunk://#diff-8a51a7b6bb8559847a294e42f46fb654f7f167970cdeeb7871e1618e497e5fe0R6): Imported `JsonStringifyResult` and updated the `AnyResponse` type to use `JsonStringifyResult` for response bodies. [[1]](diffhunk://#diff-8a51a7b6bb8559847a294e42f46fb654f7f167970cdeeb7871e1618e497e5fe0R6) [[2]](diffhunk://#diff-8a51a7b6bb8559847a294e42f46fb654f7f167970cdeeb7871e1618e497e5fe0L233-R234)
* [`pkgs/typed-api-spec/src/fetch/index.t-test.ts`](diffhunk://#diff-6bfb1dd25ea05a229cda215da2cf9430ec88145f80c86c2ffade460366ffc409L9-R9): Added new test cases to validate the `JsonStringifyResult` type within the fetch module. [[1]](diffhunk://#diff-6bfb1dd25ea05a229cda215da2cf9430ec88145f80c86c2ffade460366ffc409L9-R9) [[2]](diffhunk://#diff-6bfb1dd25ea05a229cda215da2cf9430ec88145f80c86c2ffade460366ffc409R389-R409)