### PR TITLE
Allow to omit init arg of fetch

### DIFF
--- a/pkgs/typed-api-spec/src/fetch/index.t-test.ts
+++ b/pkgs/typed-api-spec/src/fetch/index.t-test.ts
@@ -45,12 +45,21 @@ type ValidateUrlTestCase = [
         };
       };
     };
+    "/users2": {
+      get: {
+        headers: { "x-foo"?: string; "x-bar"?: string };
+        responses: { 200: { body: { prop: string } } };
+      };
+    };
   }>;
   (async () => {
     const f = fetch as FetchT<"", Spec>;
     {
-      // @ts-expect-error 今はinitの省略ができないが、できるようにしたい
+      // get methodが定義されており、headersが必要ない場合、Initは省略可能
       await f("/users");
+
+      // headersが定義されていても、すべて省略可能な場合はInitも省略可能
+      await f("/users2");
 
       // methodを省略した場合はgetとして扱う
       const res = await f("/users", {});
@@ -60,6 +69,31 @@ type ValidateUrlTestCase = [
       const contentType: "application/json" = res.headers.get("Content-Type");
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const hasContentType: true = res.headers.has("Content-Type");
+    }
+  })();
+}
+{
+  type Spec = DefineApiEndpoints<{
+    "/users": {
+      get: {
+        headers: { "x-foo"?: string; "Content-Type": "application/json" };
+        responses: { 200: { body: { prop: string } } };
+      };
+    };
+    "/users2": {
+      post: {
+        responses: { 200: { body: { prop: string } } };
+      };
+    };
+  }>;
+  (async () => {
+    const f = fetch as FetchT<"", Spec>;
+    {
+      // @ts-expect-error getメソッドが定義されていても、headersが要求されている場合はInitは省略できない
+      await f("/users");
+
+      // @ts-expect-error getメソッドが定義されていない場合、Initは省略できない
+      await f("/users2");
     }
   })();
 }

--- a/pkgs/typed-api-spec/src/fetch/index.ts
+++ b/pkgs/typed-api-spec/src/fetch/index.ts
@@ -75,7 +75,7 @@ export type RequestInitT<
 /**
  * FetchT is a type for window.fetch like function but more strict type information
  *
- * @template UrlPrefix - url prefix of `Input`
+ * @template UrlPrefix - URL prefix of `Input`
  * For example, if `UrlPrefix` is "https://example.com", then `Input` must be `https://example.com/${string}`
  *
  * @template E - ApiEndpoints
@@ -83,17 +83,17 @@ export type RequestInitT<
  */
 type FetchT<UrlPrefix extends UrlPrefixPattern, E extends ApiEndpoints> = <
   /**
-   * internal type for FetchT
+   * Internal type for FetchT
    * They are not supposed to be specified by the user
    *
-   * @template UrlPattern - Acceptable url pattern
-   * For example, if endpoints is defined as below:
+   * @template UrlPattern - Acceptable URL pattern
+   * For example, if endpoints are defined as below:
    * { "/users": ..., "/users/:userId": ... }
    * and UrlPrefix is "https://example.com",
    * then UrlPattern will be "https://example.com/users" | "https://example.com/users/${string}"
    *
    * @template Input - Input of the request by the user
-   * For example, if endpoints is defined as below:
+   * For example, if endpoints are defined as below:
    * { "/users": ..., "/users/:userId": ... }
    * then Input accepts "https://example.com/users" | "https://example.com/users/${string}"
    * If query is defined in the spec, Input also accepts "https://example.com/users?${string}" | "https://example.com/users/${string}?${string}"
@@ -102,27 +102,39 @@ type FetchT<UrlPrefix extends UrlPrefixPattern, E extends ApiEndpoints> = <
    * For example, if Input is "https://example.com/users/1", then InputPath will be "/users/${string}"
    *
    * @template CandidatePaths - Matched paths from `InputPath` and `keyof E`
-   * For example, if InputPath is "/users/1" and endpoints is defined as below:
+   * For example, if InputPath is "/users/1" and endpoints are defined as below:
    * { "/users": ..., "/users/:userId": ... }
    * then CandidatePaths will be "/users/:userId"
    * If no matched path is found, CandidatePaths will be never
-   * If multiple matched paths are found, CandidatePaths will be union of matched paths
+   * If multiple matched paths are found, CandidatePaths will be a union of matched paths
    *
    * @template AcceptableMethods - Acceptable methods for the matched path
-   * For example, if CandidatePaths is "/users/:userId" and endpoints is defined as below:
+   * For example, if CandidatePaths is "/users/:userId" and endpoints are defined as below:
    * { "/users": { get: ... }, "/users/:userId": { get: ..., post: ... } }
    * then AcceptableMethods will be "get" | "post"
    *
-   * @template LM - Lowercase of `InputMethod`
+   * @template LM - Lowercase version of `InputMethod`
    *
-   * @template Query - Query object of endpoint which is matched with `CandidatePaths`
+   * @template Query - Query object of the endpoint that matches `CandidatePaths`
    *
-   * @template ResBody - Response body of the endpoint which is matched with `CandidatePaths`
+   * @template Headers - Request headers object of the endpoint
    *
-   * @template InputMethod - Method of the request specified by the user
+   * @template Body - Request body object of the endpoint
+   *
+   * @template Response - Response object of the endpoint that matches `CandidatePaths`
+   *
+   * @template ValidatedUrl - Result of URL validation
+   *
+   * @template InputMethod - Method of the request as specified by the user
    * For example, if `fetch` is called with `fetch("https://example.com/users", { method: "post" })`,
    * then InputMethod will be "post".
    * If `get` method is defined in the spec, method can be omitted, and it will be `get` by default
+   *
+   * @template CanOmitMethod - Whether the method property in the "init" parameter can be omitted
+   * If the endpoint defines a "get" method, then the method can be omitted
+   *
+   * @template CanOmitInit - Whether the "init" parameter can be omitted for the request
+   * If the method can be omitted (`CanOmitMethod` is true) and the endpoint does not require headers, then the "init" parameter can be omitted
    */
   UrlPattern extends ToUrlParamPattern<`${UrlPrefix}${keyof E & string}`>,
   Input extends Query extends undefined


### PR DESCRIPTION
This pull request includes changes to the `pkgs/typed-api-spec` package, focusing on enhancing the `fetch` module's flexibility and correctness. The most important changes involve extending type definitions and updating test cases to reflect these improvements.

Enhancements to type definitions:

* [`pkgs/typed-api-spec/src/fetch/index.ts`](diffhunk://#diff-fab7b7d499325d868bb244d554326cafe387c331d52b0a756f04ac94b854c04bR144-R145): Added `Headers` and `Body` type parameters to the `FetchT` type and introduced `CanOmitMethod` and `CanOmitInit` boolean type parameters to determine if the `init` parameter can be omitted based on method and headers conditions. [[1]](diffhunk://#diff-fab7b7d499325d868bb244d554326cafe387c331d52b0a756f04ac94b854c04bR144-R145) [[2]](diffhunk://#diff-fab7b7d499325d868bb244d554326cafe387c331d52b0a756f04ac94b854c04bR159-R177)

Updates to test cases:

* [`pkgs/typed-api-spec/src/fetch/index.t-test.ts`](diffhunk://#diff-6bfb1dd25ea05a229cda215da2cf9430ec88145f80c86c2ffade460366ffc409R48-R63): Added new endpoint definitions and test cases to validate the behavior when headers are optional or required, and when methods other than `get` are used. [[1]](diffhunk://#diff-6bfb1dd25ea05a229cda215da2cf9430ec88145f80c86c2ffade460366ffc409R48-R63) [[2]](diffhunk://#diff-6bfb1dd25ea05a229cda215da2cf9430ec88145f80c86c2ffade460366ffc409R75-R99)