### PR TITLE
Fix init omitting logic

### DIFF
--- a/pkgs/typed-api-spec/src/core/type.t-test.ts
+++ b/pkgs/typed-api-spec/src/core/type.t-test.ts
@@ -2,6 +2,7 @@ import { Equal, Expect } from "./type-test";
 import {
   AllKeys,
   AllValues,
+  And,
   CountChar,
   ExtractByPrefix,
   FilterNever,
@@ -140,4 +141,18 @@ type AllKeysTestCases = [
 type AllValuesTestCases = [
   Expect<Equal<AllValues<{ a: 1 } | { a: 2 }, "a">, 1 | 2>>,
   Expect<Equal<AllValues<{ a: 1; b: 3 } | { a: 2 }, "b">, 3>>,
+];
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type AndTestCases = [
+  Expect<Equal<And<[]>, true>>, // An empty tuple evaluates to true
+  Expect<Equal<And<[true]>, true>>, // Single element true
+  Expect<Equal<And<[false]>, false>>, // Single element false
+  Expect<Equal<And<[true, true]>, true>>, // All elements are true
+  Expect<Equal<And<[true, false]>, false>>, // Contains false
+  Expect<Equal<And<[false, true]>, false>>, // Contains false
+  Expect<Equal<And<[false, false]>, false>>, // All elements are false
+  Expect<Equal<And<[true, true, true]>, true>>, // Multiple true elements
+  Expect<Equal<And<[true, true, false]>, false>>, // Multiple elements containing false
+  Expect<Equal<And<boolean[]>, boolean>>, // boolean[] type
 ];

--- a/pkgs/typed-api-spec/src/core/type.ts
+++ b/pkgs/typed-api-spec/src/core/type.ts
@@ -159,3 +159,24 @@ export type AllValues<T, Key extends AllKeys<T>> = T extends {
 }
   ? T[Key]
   : never;
+
+/**
+ * Computes the logical AND of a tuple of boolean types at the type level.
+ * @template T - A readonly tuple of boolean types (true | false | boolean)
+ */
+export type And<T extends readonly boolean[]> = T extends readonly []
+  ? // The AND of an empty tuple is true (identity element of logical AND)
+    true
+  : // Can T be decomposed into [Head, ...Tail]? (Recursive step)
+    T extends readonly [
+        infer Head extends boolean,
+        ...infer Tail extends readonly boolean[],
+      ]
+    ? Head extends false
+      ? // If Head is false, the AND of the entire tuple is false
+        false
+      : // If Head is true, the result depends on the AND of the remaining elements (Tail)
+        And<Tail>
+    : // If T is neither [] nor [Head, ...Tail] (e.g., boolean[] type itself)
+      // In this case, the result cannot be determined and is therefore boolean.
+      boolean;

--- a/pkgs/typed-api-spec/src/fetch/index.t-test.ts
+++ b/pkgs/typed-api-spec/src/fetch/index.t-test.ts
@@ -266,6 +266,30 @@ type ValidateUrlTestCase = [
 
 {
   type Spec = DefineApiEndpoints<{
+    "/users": {
+      get: {
+        // 本来、GETメソッドはbodyを持たないが、型エラーになることを確認するために定：w
+        body: { userName: string };
+        responses: { 200: { body: { prop: string } } };
+      };
+    };
+  }>;
+  (async () => {
+    const f = fetch as FetchT<"", Spec>;
+
+    // @ts-expect-error init cannot be omitted when request body is required
+    await f("/users");
+
+    // Valid case: init is provided with required body
+    await f("/users", {
+      method: "get",
+      body: JSONT.stringify({ userName: "test" }),
+    });
+  })();
+}
+
+{
+  type Spec = DefineApiEndpoints<{
     "/packages/list": {
       get: {
         headers: { Cookie: `a=${string}` };

--- a/pkgs/typed-api-spec/src/fetch/index.t-test.ts
+++ b/pkgs/typed-api-spec/src/fetch/index.t-test.ts
@@ -268,7 +268,7 @@ type ValidateUrlTestCase = [
   type Spec = DefineApiEndpoints<{
     "/users": {
       get: {
-        // 本来、GETメソッドはbodyを持たないが、型エラーになることを確認するために定：w
+        // 本来、GETメソッドはbodyを持たないが、型エラーになることを確認するために定義
         body: { userName: string };
         responses: { 200: { body: { prop: string } } };
       };


### PR DESCRIPTION
This pull request includes several changes to improve type safety and documentation in the `pkgs/docs/docs/04_client/overview.md` and `pkgs/typed-api-spec` files. The most important changes include removing unnecessary parameters from fetch calls, adding a new `And` type, and updating the `FetchT` type to enforce stricter type checks.

Improvements to type safety in fetch calls:

* [`pkgs/docs/docs/04_client/overview.md`](diffhunk://#diff-de82e9d8ae1e720e9ca0ce3f6234baa28850270329cbedaca4ba80082d954dc3L38-R38): Removed unnecessary empty object parameters from fetch calls to simplify the code and improve readability. [[1]](diffhunk://#diff-de82e9d8ae1e720e9ca0ce3f6234baa28850270329cbedaca4ba80082d954dc3L38-R38) [[2]](diffhunk://#diff-de82e9d8ae1e720e9ca0ce3f6234baa28850270329cbedaca4ba80082d954dc3L60-R60) [[3]](diffhunk://#diff-de82e9d8ae1e720e9ca0ce3f6234baa28850270329cbedaca4ba80082d954dc3L108-R111) [[4]](diffhunk://#diff-de82e9d8ae1e720e9ca0ce3f6234baa28850270329cbedaca4ba80082d954dc3L129-R131)

Enhancements to type definitions and tests:

* [`pkgs/typed-api-spec/src/core/type.ts`](diffhunk://#diff-5ece648786a31be333ace812c7accc5cba1e70af8fa7b1972f01f379abee9dccR162-R182): Added a new `And` type to compute the logical AND of a tuple of boolean types at the type level.
* [`pkgs/typed-api-spec/src/core/type.t-test.ts`](diffhunk://#diff-702c6f19adfb8cd6d55efeaa9d3580eba30e5f9da3d4eebfa95977ede6e3cf67R145-R158): Added test cases for the new `And` type to ensure its correctness.

Updates to `FetchT` type:

* [`pkgs/typed-api-spec/src/fetch/index.ts`](diffhunk://#diff-fab7b7d499325d868bb244d554326cafe387c331d52b0a756f04ac94b854c04bR123-R128): Updated the `FetchT` type to include new template parameters `CanOmitHeaders` and `CanOmitBody`, and modified the `CanOmitInit` parameter to use the new `And` type for stricter type checks. [[1]](diffhunk://#diff-fab7b7d499325d868bb244d554326cafe387c331d52b0a756f04ac94b854c04bR123-R128) [[2]](diffhunk://#diff-fab7b7d499325d868bb244d554326cafe387c331d52b0a756f04ac94b854c04bL137-R142) [[3]](diffhunk://#diff-fab7b7d499325d868bb244d554326cafe387c331d52b0a756f04ac94b854c04bR162-R166) [[4]](diffhunk://#diff-fab7b7d499325d868bb244d554326cafe387c331d52b0a756f04ac94b854c04bR176-R183)

Documentation improvements:

* [`pkgs/docs/docs/04_client/overview.md`](diffhunk://#diff-de82e9d8ae1e720e9ca0ce3f6234baa28850270329cbedaca4ba80082d954dc3R178-R234): Added a new section to explain the type safety enforcement for the `init` parameter in fetch calls, ensuring adherence to API specifications.

These changes collectively enhance the type safety and clarity of the codebase, making it easier to maintain and less prone to runtime errors.