### PR TITLE
Fix JsonStringifyResult bug with tupple

### DIFF
--- a/pkgs/typed-api-spec/src/fetch/index.t-test.ts
+++ b/pkgs/typed-api-spec/src/fetch/index.t-test.ts
@@ -118,7 +118,6 @@ type ValidateUrlTestCase = [
   (async () => {
     const f = fetch as FetchT<"", JsonSpec>;
     const f2 = fetch as FetchT<"", Spec>;
-    const JSONT = JSON as JSONT;
     {
       // @ts-expect-error fetch requires input
       f();

--- a/pkgs/typed-api-spec/src/json/index.test.ts
+++ b/pkgs/typed-api-spec/src/json/index.test.ts
@@ -20,6 +20,7 @@ describe("JsonStringifyResult", () => {
       k: (string | undefined | Date)[];
       [l]: string;
       m: { toJSON: () => { x: number; y: string | undefined } };
+      n: [number, number];
     };
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     type T = Expect<
@@ -35,6 +36,7 @@ describe("JsonStringifyResult", () => {
           k: (string | null)[];
           // FIXME: y should be optional
           m: { x: number; y: string | undefined };
+          n: [number, number];
         }
       >
     >;
@@ -55,6 +57,7 @@ describe("JsonStringifyResult", () => {
       k: ["a", undefined, new Date("2021-01-01")],
       [l]: "symbol keyed value",
       m: { toJSON: () => ({ x: 1, y: undefined }) },
+      n: [1, 2],
     };
 
     expect(JSON.parse(JSON.stringify({ ...example, h: undefined }))).toEqual({
@@ -66,6 +69,7 @@ describe("JsonStringifyResult", () => {
       j: { nested: "world" },
       k: ["a", null, "2021-01-01T00:00:00.000Z"],
       m: { x: 1 },
+      n: [1, 2],
     });
   });
 });

--- a/pkgs/typed-api-spec/src/json/index.ts
+++ b/pkgs/typed-api-spec/src/json/index.ts
@@ -20,22 +20,24 @@ type JsonPrimitive = string | number | boolean | null | Date;
 // eslint-disable-next-line @typescript-eslint/ban-types
 type InvalidJsonValue = undefined | Function | symbol | bigint;
 
-type JsonifyArrayElement<T> = T extends InvalidJsonValue ? null : Jsonify<T>;
-
 type JsonifyObject<T> = {
   [K in keyof T as K extends string
-    ? Jsonify<T[K]> extends infer ProcessedValue
-      ? ProcessedValue extends InvalidJsonValue
-        ? never
-        : K
-      : never
+    ? T[K] extends InvalidJsonValue
+      ? never
+      : K
     : never]: Jsonify<T[K]>;
 };
 
-// タプル型を保持するためのヘルパー型
-type JsonifyTuple<T extends readonly unknown[]> = {
-  [K in keyof T]: T[K] extends InvalidJsonValue ? null : Jsonify<T[K]>;
-};
+// タプル型を保持するためのヘルパー型 - 再帰の深さを制限
+type JsonifyTuple<T extends readonly unknown[]> = T extends [
+  infer First,
+  ...infer Rest,
+]
+  ? [
+      First extends InvalidJsonValue ? null : Jsonify<First>,
+      ...JsonifyTuple<Rest>,
+    ]
+  : [];
 
 type Jsonify<T> = T extends { toJSON(): infer R }
   ? Jsonify<R>
@@ -45,10 +47,10 @@ type Jsonify<T> = T extends { toJSON(): infer R }
       ? T
       : T extends InvalidJsonValue
         ? T
-        : T extends readonly [unknown, ...unknown[]] // T may be tuple
+        : T extends readonly [unknown, ...unknown[]] // タプル型の特別処理
           ? JsonifyTuple<T>
-          : T extends Array<infer E>
-            ? Array<JsonifyArrayElement<E>>
+          : T extends (infer E)[]
+            ? (E extends InvalidJsonValue ? null : Jsonify<E>)[]
             : T extends object
               ? JsonifyObject<T>
               : never;

--- a/pkgs/typed-api-spec/src/json/index.ts
+++ b/pkgs/typed-api-spec/src/json/index.ts
@@ -20,47 +20,38 @@ type JsonPrimitive = string | number | boolean | null | Date;
 // eslint-disable-next-line @typescript-eslint/ban-types
 type InvalidJsonValue = undefined | Function | symbol | bigint;
 
-// 配列要素の変換: 不適切な値は null に
 type JsonifyArrayElement<T> = T extends InvalidJsonValue ? null : Jsonify<T>;
 
-// オブジェクトの変換
 type JsonifyObject<T> = {
-  // keyof T から string 型のキーのみを抽出 (シンボルキーを除外)
   [K in keyof T as K extends string
-    ? // プロパティの値 T[K] を Jsonify した結果を ProcessedValue とする
-      Jsonify<T[K]> extends infer ProcessedValue
-      ? // ProcessedValue が 不適切な型なら、このプロパティ自体を除外 (never)
-        ProcessedValue extends InvalidJsonValue
+    ? Jsonify<T[K]> extends infer ProcessedValue
+      ? ProcessedValue extends InvalidJsonValue
         ? never
-        : // そうでなければキー K を採用
-          K
+        : K
       : never
-    : never]: Jsonify<T[K]>; // ↑で採用されたキー K に対して、変換後の値 ProcessedValue を割り当て
+    : never]: Jsonify<T[K]>;
 };
 
-// メインの再帰型
-type Jsonify<T> =
-  // 1. toJSONメソッドを持つか？ -> あればその返り値を Jsonify
-  T extends { toJSON(): infer R }
-    ? Jsonify<R>
-    : // 2. Dateか？ -> string
-      T extends Date
-      ? string
-      : // 3. その他のプリミティブか？ -> そのまま
-        T extends JsonPrimitive
-        ? T
-        : // 4. 不適切な値か？ -> そのまま (呼び出し元で処理)
-          T extends InvalidJsonValue
-          ? T
-          : // 5. 配列か？ -> 各要素を JsonifyArrayElement で変換
-            T extends Array<infer E>
-            ? Array<JsonifyArrayElement<E>>
-            : // 6. オブジェクトか？ -> JsonifyObject で変換
-              T extends object
-              ? JsonifyObject<T>
-              : // 7. それ以外 (通常は到達しない) -> never
-                never;
+// タプル型を保持するためのヘルパー型
+type JsonifyTuple<T extends readonly unknown[]> = {
+  [K in keyof T]: T[K] extends InvalidJsonValue ? null : Jsonify<T[K]>;
+};
 
-// 最終的な型: トップレベルでの undefined/function/symbol/bigint は undefined になる
+type Jsonify<T> = T extends { toJSON(): infer R }
+  ? Jsonify<R>
+  : T extends Date
+    ? string
+    : T extends JsonPrimitive
+      ? T
+      : T extends InvalidJsonValue
+        ? T
+        : T extends readonly [unknown, ...unknown[]] // T may be tuple
+          ? JsonifyTuple<T>
+          : T extends Array<infer E>
+            ? Array<JsonifyArrayElement<E>>
+            : T extends object
+              ? JsonifyObject<T>
+              : never;
+
 export type JsonStringifyResult<T> =
   Jsonify<T> extends InvalidJsonValue ? undefined : Jsonify<T>;


### PR DESCRIPTION
This pull request enhances the `JsonStringifyResult` functionality by adding support for tuple types and updating related tests to ensure proper handling of tuples during JSON serialization. The changes include the addition of a helper type for tuples, updates to the `Jsonify` type to support tuple serialization, and corresponding test cases.

### Enhancements to JSON serialization:

* Added a new helper type `JsonifyTuple` to handle tuple serialization, ensuring tuple elements are properly transformed during the JSONification process. This includes converting invalid JSON values like `undefined` to `null`. (`pkgs/typed-api-spec/src/json/index.ts`, [pkgs/typed-api-spec/src/json/index.tsL23-L64](diffhunk://#diff-12aeec546b44b4b802c57f8c8e3040497d486fc6fa77bb72bd4ad5b06eff5c32L23-L64))
* Updated the `Jsonify` type to integrate `JsonifyTuple` for handling tuples, distinguishing tuples from regular arrays and ensuring they are serialized correctly. (`pkgs/typed-api-spec/src/json/index.ts`, [pkgs/typed-api-spec/src/json/index.tsL23-L64](diffhunk://#diff-12aeec546b44b4b802c57f8c8e3040497d486fc6fa77bb72bd4ad5b06eff5c32L23-L64))

### Test updates:

* Added a new property `n` (a tuple `[number, number]`) to the test cases in `JsonStringifyResult` to validate tuple serialization. This includes updates to the example data and expected JSON output to ensure proper handling of tuples. (`pkgs/typed-api-spec/src/json/index.test.ts`, [[1]](diffhunk://#diff-7962c46348d0e41ce75116566a4215ad32bf7a3353e4c07098db365b445f269eR23) [[2]](diffhunk://#diff-7962c46348d0e41ce75116566a4215ad32bf7a3353e4c07098db365b445f269eR39) [[3]](diffhunk://#diff-7962c46348d0e41ce75116566a4215ad32bf7a3353e4c07098db365b445f269eR60) [[4]](diffhunk://#diff-7962c46348d0e41ce75116566a4215ad32bf7a3353e4c07098db365b445f269eR72)