### PR TITLE
Export TypedString, JsonStringifyResult, Jsonify, JsonifyObject

### DIFF
--- a/pkgs/typed-api-spec/src/index.ts
+++ b/pkgs/typed-api-spec/src/index.ts
@@ -21,8 +21,21 @@ export {
 import FetchT, { RequestInitT } from "./fetch";
 export { FetchT, RequestInitT };
 
-import JSONT, { JSON$stringifyT } from "./json";
-export { JSONT, JSON$stringifyT };
+import JSONT, {
+  JSON$stringifyT,
+  TypedString,
+  JsonStringifyResult,
+  Jsonify,
+  JsonifyObject,
+} from "./json";
+export {
+  JSONT,
+  JSON$stringifyT,
+  TypedString,
+  JsonStringifyResult,
+  Jsonify,
+  JsonifyObject,
+};
 
 export {
   newHttp as newMswHttp,

--- a/pkgs/typed-api-spec/src/json/index.ts
+++ b/pkgs/typed-api-spec/src/json/index.ts
@@ -20,7 +20,7 @@ type JsonPrimitive = string | number | boolean | null | Date;
 // eslint-disable-next-line @typescript-eslint/ban-types
 type InvalidJsonValue = undefined | Function | symbol | bigint;
 
-type JsonifyObject<T> = {
+export type JsonifyObject<T> = {
   [K in keyof T as K extends string
     ? T[K] extends InvalidJsonValue
       ? never
@@ -39,7 +39,7 @@ type JsonifyTuple<T extends readonly unknown[]> = T extends [
     ]
   : [];
 
-type Jsonify<T> = T extends { toJSON(): infer R }
+export type Jsonify<T> = T extends { toJSON(): infer R }
   ? Jsonify<R>
   : T extends Date
     ? string


### PR DESCRIPTION
This pull request introduces new exports and modifies existing types in the `typed-api-spec` package to enhance JSON handling capabilities. The changes focus on making additional type definitions available for external use and improving type definitions for JSON transformation.

### Enhancements to JSON-related exports:

* [`pkgs/typed-api-spec/src/index.ts`](diffhunk://#diff-431dd80d726cfc46bed7c3a373dcb7968e8a706eb9ec83e5e6cf112293ab8e65L24-R38): Added new exports for `TypedString`, `JsonStringifyResult`, `Jsonify`, and `JsonifyObject` from the `json` module, making these types available for external use.

### Improvements to type definitions:

* [`pkgs/typed-api-spec/src/json/index.ts`](diffhunk://#diff-12aeec546b44b4b802c57f8c8e3040497d486fc6fa77bb72bd4ad5b06eff5c32L23-R23): Updated `JsonifyObject` to be an exported type, allowing it to be used outside the module.
* [`pkgs/typed-api-spec/src/json/index.ts`](diffhunk://#diff-12aeec546b44b4b802c57f8c8e3040497d486fc6fa77bb72bd4ad5b06eff5c32L42-R42): Updated `Jsonify` to be an exported type, enabling external usage for transforming objects into JSON-compatible types.