### PR TITLE
chore(ci): trigger を絞り workflow 二重起動を解消

### DIFF
--- a/.github/workflows/all.yaml
+++ b/.github/workflows/all.yaml
@@ -1,6 +1,9 @@
 name: all
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
## 概要
`all.yaml` の trigger を修正し、PR branch への push で workflow が 2 回走る問題を解消。

<img width="823" height="322" alt="Screenshot 2026-08-13 at 15 06 43" src="https://github.com/user-attachments/assets/0c2489d0-49f2-408d-a4dc-a209bdddf710" />
