### PR TITLE
chore(deps): update brace-expansion to version 1.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13054,9 +13054,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23873,9 +23873,9 @@
       }
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",


### PR DESCRIPTION
## 概要
- `brace-expansion` の 2 経路（`eslint > minimatch` の 1.1.11、`serve-handler > minimatch` の 1.1.15）を `npm update brace-expansion` で 1.1.18 に更新

## 対象アラート

- https://github.com/nota/typed-api-spec/security/dependabot/202
- https://github.com/nota/typed-api-spec/security/dependabot/201
- https://github.com/nota/typed-api-spec/security/dependabot/180

いずれも `< 1.1.18` が対象、1.1.18 で全て patched。

