### PR TITLE
ci(dependabot): github-actions の cooldown を 5 日に変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,6 @@ updates:
     schedule:
       interval: 'daily'
     cooldown:
-      default-days: 3
+      default-days: 5
     labels:
       - 'dependencies'


### PR DESCRIPTION
## 背景
Dependabot が bump した SHA が pinact の `check-pinned-actions` job で `min-age violation` を出して CI が失敗する事例が繰り返し発生。

失敗した job:
- [PR #288 (1.0.199)](https://github.com/nota/typed-api-spec/actions/runs/32693261769/job/97330617413)
- [PR #287 (1.0.195)](https://github.com/nota/typed-api-spec/actions/runs/32449824816/job/96676087594)
- [PR (1.0.194)](https://github.com/nota/typed-api-spec/actions/runs/32334828384/job/96323190117)
- [PR (1.0.191)](https://github.com/nota/typed-api-spec/actions/runs/31772357235/job/94680721143)
- [PR (1.0.190)](https://github.com/nota/typed-api-spec/actions/runs/31669622763/job/94351380690)

原因（PR #287 の実測）:
- v1.0.195 の release publish: 2026-08-18 20:40 UTC
- Dependabot が PR 作成: 2026-08-21 05:14 UTC (publish から約 2.4 日後)
- pinact は厳密に「commit が現時刻 - 72 時間より古いこと」を要求 → cutoff 2026-08-18 05:14 UTC → NG


## 修正内容

- 5 日にすることで pinact 3 日に対し 2 日のバッファができる