### PR TITLE
chore(deps): bump ajv from 8.17.1 to 8.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13249,9 +13249,9 @@
       }
     },
     "node_modules/fastify/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
## Summary
- `fastify > @fastify/ajv-compiler > ajv` の nested resolve が `8.17.1` のままだったので `8.20.0` に更新
- Dependabot alert [#63](https://github.com/nota/typed-api-spec/security/dependabot/63) を解消

## Fixed advisory

Vulnerable range: `>= 7.0.0-alpha.0, < 8.18.0` / Patched: `8.18.0`

## Changes
- `package-lock.json` のみ更新（`package.json` 変更なし）
- 対象 entry: `node_modules/fastify/node_modules/ajv`: 8.17.1 → 8.20.0

その他 ajv@8.20.0（webpack-dev-server 経由）と ajv@6.15.0（vulnerable_range 外）はもともと存在、変更なし。

## Test plan
- [x] `npm ci` が成功する
- [x] 既存 CI (lint / test / build) がグリーン
- [x] `npm ls ajv` で `8.17.1` が消えていること

```
typed-api-spec@ /Users/helpfeel2/Documents/typed-api-spec
├─┬ @notainc/typed-api-spec@0.9.0 -> ./pkgs/typed-api-spec
│ ├─┬ eslint@9.39.5
│ │ ├─┬ @eslint/eslintrc@3.3.6
│ │ │ └── ajv@6.15.0 deduped
│ │ └── ajv@6.15.0
│ └─┬ fastify@5.8.5
│   ├─┬ @fastify/ajv-compiler@4.0.5
│   │ ├─┬ ajv-formats@3.0.1
│   │ │ └── ajv@8.20.0 deduped
│   │ └── ajv@8.20.0
│   └─┬ fast-json-stringify@6.1.1
│     └── ajv@8.20.0 deduped
└─┬ docs@0.0.0 -> ./pkgs/docs
  └─┬ @docusaurus/core@3.10.2
    ├─┬ @docusaurus/bundler@3.10.2
    │ ├─┬ file-loader@6.2.0
    │ │ └─┬ schema-utils@3.3.0
    │ │   ├─┬ ajv-keywords@3.5.2
    │ │   │ └── ajv@6.15.0 deduped
    │ │   └── ajv@6.15.0 deduped
    │ ├─┬ null-loader@4.0.1
    │ │ └─┬ schema-utils@3.3.0
    │ │   └── ajv@6.15.0 deduped
    │ └─┬ url-loader@4.1.1
    │   └─┬ schema-utils@3.3.0
    │     └── ajv@6.15.0 deduped
    └─┬ webpack-dev-server@5.2.6
      └─┬ schema-utils@4.3.3
        ├─┬ ajv-formats@2.1.1
        │ └── ajv@8.20.0
        ├─┬ ajv-keywords@5.1.0
        │ └── ajv@8.20.0 deduped
        └── ajv@8.20.0
```