### PR TITLE
ci(docs): pkgs/docs のビルドに型チェックを組み込む

### DIFF
--- a/pkgs/docs/package.json
+++ b/pkgs/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "tsc && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
## 概要
`pkgs/docs` の `build` スクリプトを `docusaurus build` から `tsc && docusaurus build` に変更。

`pkgs/docs` には `typecheck` (`tsc`) スクリプトが存在するが、CI で呼ばれておらず、型エラーがあっても気づけない状態だった。

`examples/vite` (`tsc && vite build`) や `examples/vite-react-openapi` (`tsc -b && vite build`) は既に build 側で型チェックを行っており、それに合わせる形で修正。

### きっかけ
#297 (react 18→19 bump) のレビューで、`@types/react@19` により `JSX.Element` グローバル namespace が廃止され、`pkgs/docs` 内 3 箇所が型エラーになることが判明。`pkgs/docs` の CI では検知できていなかった。

## スコープ外
- `JSX.Element` → `ReactNode` への実際の修正は #297 側で対応
