### PR TITLE
chore(ci): CIとpublishのNode/npmバージョンを固定

### DIFF
--- a/.github/workflows/all.yaml
+++ b/.github/workflows/all.yaml
@@ -5,12 +5,19 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  node-version: 24.20.0
+  npm-version: 11.19.0
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.node-version }}
+      - run: npm install -g npm@${{ env.npm-version }}
       - run: npm ci -w pkgs/typed-api-spec
       - run: npm run build  -w pkgs/typed-api-spec
       - run: npm test -w pkgs/typed-api-spec
@@ -19,6 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.node-version }}
+      - run: npm install -g npm@${{ env.npm-version }}
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - run: npm ci -w pkgs/docs
       - run: npm run build -w pkgs/docs
@@ -27,6 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.node-version }}
+      - run: npm install -g npm@${{ env.npm-version }}
       - run: npm ci
       - run: npm run build -w pkgs/typed-api-spec
       - run: npm test -w examples/misc

--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -8,6 +8,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  node-version: 24.20.0
+  npm-version: 11.19.0
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
@@ -30,6 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.node-version }}
+      - run: npm install -g npm@${{ env.npm-version }}
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - run: npm ci -w pkgs/docs
       - run: npm run build -w pkgs/docs

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - "v*.*.*"
+env:
+  node-version: 24.20.0
+  npm-version: 11.19.0
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -24,8 +27,9 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '24'
+          node-version: ${{ env.node-version }}
           registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm@${{ env.npm-version }}
       - run: npm ci
       - run: npm run build -w pkgs/typed-api-spec
       - run: npm publish -w pkgs/typed-api-spec --access public --provenance

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "engines": {
+    "node": "24.20.0",
+    "npm": "11.19.0"
+  },
   "workspaces": [
     "pkgs/*",
     "examples/*"


### PR DESCRIPTION
## Summary
- CI (`all.yaml` / `doc.yaml`) と publish (`publish.yaml`) で Node/npm のバージョンがバラバラ(指定なし or ハードコード)だったのを、各 workflow の `env` で明示的に固定
- `package.json` に `engines.node` / `engines.npm` を追加し、リポジトリが前提とする Node/npm バージョンを明記

## Changes
- `all.yaml` / `doc.yaml` / `publish.yaml` の先頭に `env: node-version: 24.20.0, npm-version: 11.19.0` を追加
- 各 job の `actions/setup-node` に `node-version: ${{ env.node-version }}` を指定
- `setup-node` の直後に `npm install -g npm@${{ env.npm-version }}` を追加し、npm 本体のバージョンも固定
- `package.json` に `engines: { node: "24.20.0", npm: "11.19.0" }` を追加

## Test plan
- [ ] `all.yaml` / `doc.yaml` / `publish.yaml` の CI が Node/npm のバージョン固定込みで成功する
