### PR TITLE
chore(ci): enable npm caching in workflows for improved performance

### DIFF
--- a/.github/workflows/all.yaml
+++ b/.github/workflows/all.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: npm
       - run: npm ci -w pkgs/typed-api-spec
       - run: npm run build  -w pkgs/typed-api-spec
       - run: npm test -w pkgs/typed-api-spec
@@ -19,6 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: npm
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - run: npm ci -w pkgs/docs
       - run: npm run build -w pkgs/docs
@@ -27,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: npm
       - run: npm ci
       - run: npm run build -w pkgs/typed-api-spec
       - run: npm test -w examples/misc

--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: npm
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - run: npm ci -w pkgs/docs
       - run: npm run build -w pkgs/docs

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          cache: npm
       - run: npm ci
       - run: npm run build -w pkgs/typed-api-spec
       - run: npm publish -w pkgs/typed-api-spec --access public --provenance


### PR DESCRIPTION
## 概要

`actions/setup-node` の組み込みキャッシュを有効化しCIの速度改善を行いました。

## 対応

`npm ci` を実行している全ジョブ(`all.yaml` の test/doc/examples、`doc.yaml` の deploy、`publish.yaml` の publish)の `actions/setup-node` に `cache: npm` を追加しました。

このオプションは内部で `actions/cache` を使い、`package-lock.json` のハッシュをキーにnpmのグローバルキャッシュ(`~/.npm`、`node_modules` 自体ではない)を保存・復元します。`npm ci` はいつも通り実行されますが、パッケージのダウンロード部分がキャッシュヒットで省略されるようになります。

このリポジトリはnpm workspacesでroot直下に `package-lock.json` が1つだけの構成なので、`cache-dependency-path` の明示指定なしで自動検出されます。

## 影響

CIの挙動・成果物に変更はありません。


## 検証

空コミットを1つ積んで2回CIを回し、キャッシュ作成時(1回目)とキャッシュヒット時(2回目)を比較しました。

| ジョブ | 1回目(キャッシュ作成) | 2回目(キャッシュヒット) |
|---|---|---|
| test | 30s | 26s |
| doc | 3m37s | 54s |
| examples | 7m33s | 56s |

`doc`・`examples`ともに短縮されています。
